### PR TITLE
Nav bar in CMS

### DIFF
--- a/layouts/neighbor.jsx
+++ b/layouts/neighbor.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useState } from 'react';
 import Head from 'next/head';
 import { CMSContext } from '@/context/cms';
 import Link from 'next/link'
-import { getCmsRecordFromKey, getRecordLanguages, getCmsPages } from '@/utils/cms'
+import { getCmsRecordFromKey, getRecordLanguages, getCmsPages, getCmsNav, RenderNavLinks } from '@/utils/cms'
 
 const NeighborLayout = ({ children }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -17,6 +17,7 @@ const NeighborLayout = ({ children }) => {
   const footer = getCmsRecordFromKey('contact', state);
   const languages = getRecordLanguages(state);
   const pages = getCmsPages(state);
+  const nav = getCmsNav(state);
 
   const setLanguage = (language) => {
     dispatch({ type: 'set-language', payload: language });
@@ -49,15 +50,9 @@ const NeighborLayout = ({ children }) => {
           <button className="usa-nav__close" onClick={() => setIsMenuOpen(false)}>
             <img src="/assets/img/close.svg" alt="close" />
           </button>
-          <ul className="usa-nav__primary usa-accordion">
-            {
-              pages.map(page => {
-                return <li key={page.key} className="usa-nav__primary-item">
-                  <Link href="/[pid]" as={`/${page.key}`}><a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a></Link>
-                </li>
-              })
-            }
-          </ul>
+          {
+            <RenderNavLinks key="nav" navs={nav} pages={pages} />
+          }
           <Link href="/request"><a className="usa-button" href="/request">
             {cta.body}
           </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6377,6 +6377,11 @@
       "resolved": "https://registry.npmjs.org/react-process-string/-/react-process-string-1.2.0.tgz",
       "integrity": "sha512-+ExcVuECeALN6PTqj2XyjqkxzRdUmZv6bb15fjEMwzo9SbXzDzOr8R8RTwzPzQpCxiSGfqf3JPjOHGMiRuQ8Eg=="
     },
+    "react-recipes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-recipes/-/react-recipes-1.0.0.tgz",
+      "integrity": "sha512-/wPuGzxh07mJxma1oYJbyYkGNvI2Px5DHWfqYyWJlUuMHVefEQMwpv3wIYg9Jyw+NmdWYca6717aLTV/ulkXQw=="
+    },
     "react-string-replace": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-0.4.4.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-process-string": "^1.2.0",
+    "react-recipes": "^1.0.0",
     "react-string-replace": "^0.4.4"
   },
   "engines": {

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import Text from '@/components/Text';
 import Hero from '@/components/Hero';
 import HeroWithButtons from '@/components/HeroWithButtons';
@@ -6,7 +6,7 @@ import Form from '@/components/Form';
 import Button from '@/components/Button';
 import reactStringReplace from 'react-string-replace';
 import Link from 'next/link'
-
+import { useOnClickOutside } from "react-recipes";
 import Markdown from 'markdown-to-jsx';
 
 /**
@@ -65,10 +65,16 @@ export function getCmsNav(state) {
 const AccordionNav = ({nav, pages}) => {
   const [open, setOpen] = useState(false);
   const aria_id = `basic-nav-section-${nav.key}`;
+  // Create a ref that we add to the element for which we want to detect outside clicks
+  const ref = useRef();
+
+  // Call hook passing in the ref and a function to call on outside click
+  useOnClickOutside(ref, () => setOpen(false));
+
   const menuOpenStyles = {
     display: open ? 'inline' : ''
   }
-  return <li key={nav.key} className="usa-nav__primary-item">
+  return <li key={nav.key} className="usa-nav__primary-item" ref={ref}>
     <button className="usa-accordion__button usa-nav__link"
             aria-expanded={open}
             aria-controls={aria_id}

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -4,6 +4,7 @@ import HeroWithButtons from '@/components/HeroWithButtons';
 import Form from '@/components/Form';
 import Button from '@/components/Button';
 import reactStringReplace from 'react-string-replace';
+import Link from 'next/link'
 
 import Markdown from 'markdown-to-jsx';
 
@@ -52,6 +53,47 @@ export function getCmsBlocks(page, state) {
 
 export function getCmsPages(state) {
   return state.records.filter(record => { return record.type === 'page' && record.enabled })
+}
+
+
+export function getCmsNav(state) {
+  return state.records.filter(record => { return record.type === 'nav' && record.enabled })
+}
+
+
+export const RenderNavLinks = ({navs, pages}) => {
+  return <ul className="usa-nav__primary usa-accordion">
+      {
+        navs?.map((nav) => {
+          const pageKeys = nav.data.split(",");
+          const this_pages = pages.filter(record => {return pageKeys.includes(record.key)});
+          if (this_pages.length == 1) {
+            const page = this_pages[0];
+            return <li key={nav.key} className="usa-nav__primary-item">
+              <Link href="/[pid]" as={`/${page.key}`}><a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a></Link>
+            </li>
+          } else {
+            const aria_id = `basic-nav-section-${nav.key}`;
+            return <li key={nav.key} className="usa-nav__primary-item">
+              <button className="usa-accordion__button usa-nav__link" 
+                      aria-expanded="false" 
+                      aria-controls={aria_id}>
+              <span>{nav.title}</span></button>
+              <ul id={aria_id} className="usa-nav__submenu">
+                {
+                  this_pages.map((page) => {
+                    return <li className="usa-nav__submenu-item">
+                      <a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a>
+                    </li>
+                  })
+                }
+              </ul>
+            </li>
+          }
+        })
+
+      }
+    </ul>
 }
 
 /**

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Text from '@/components/Text';
 import Hero from '@/components/Hero';
 import HeroWithButtons from '@/components/HeroWithButtons';
@@ -61,34 +62,49 @@ export function getCmsNav(state) {
 }
 
 
+const AccordionNav = ({nav, pages}) => {
+  const [open, setOpen] = useState(false);
+  const aria_id = `basic-nav-section-${nav.key}`;
+  const menuOpenStyles = {
+    display: open ? 'inline' : ''
+  }
+  return <li key={nav.key} className="usa-nav__primary-item">
+    <button className="usa-accordion__button usa-nav__link"
+            aria-expanded={open}
+            aria-controls={aria_id}
+            onClick={() => setOpen(!open)}>
+    <span>{nav.title}</span></button>
+    {open ? <ul id={aria_id} className="usa-nav__submenu">
+      {
+        pages.map((page) => {
+          return <li className="usa-nav__submenu-item">
+            <a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a>
+          </li>
+        })
+      }
+    </ul>: undefined}
+  </li>
+}
+
 export const RenderNavLinks = ({navs, pages}) => {
   return <ul className="usa-nav__primary usa-accordion">
       {
-        navs?.map((nav) => {
+        navs.length == 0 ?
+        pages.map(page => {
+        return <li key={page.key} className="usa-nav__primary-item">
+            <Link href="/[pid]" as={`/${page.key}`}><a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a></Link>
+          </li>
+        }) :
+        navs.map((nav) => {
           const pageKeys = nav.data.split(",");
           const this_pages = pages.filter(record => {return pageKeys.includes(record.key)});
           if (this_pages.length == 1) {
             const page = this_pages[0];
             return <li key={nav.key} className="usa-nav__primary-item">
-              <Link href="/[pid]" as={`/${page.key}`}><a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a></Link>
+              <Link href="/[pid]" as={`/${page.key}`}><a className="usa-nav__link" href={`/${page.key}`}><span>{nav.title}</span></a></Link>
             </li>
           } else {
-            const aria_id = `basic-nav-section-${nav.key}`;
-            return <li key={nav.key} className="usa-nav__primary-item">
-              <button className="usa-accordion__button usa-nav__link" 
-                      aria-expanded="false" 
-                      aria-controls={aria_id}>
-              <span>{nav.title}</span></button>
-              <ul id={aria_id} className="usa-nav__submenu">
-                {
-                  this_pages.map((page) => {
-                    return <li className="usa-nav__submenu-item">
-                      <a className="usa-nav__link" href={`/${page.key}`}><span>{page.title}</span></a>
-                    </li>
-                  })
-                }
-              </ul>
-            </li>
+            return <AccordionNav nav={nav} pages={this_pages}/>
           }
         })
 

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -80,7 +80,7 @@ const AccordionNav = ({nav, pages}) => {
             aria-controls={aria_id}
             onClick={() => setOpen(!open)}>
     <span>{nav.title}</span></button>
-    {open ? <ul id={aria_id} className="usa-nav__submenu">
+    {open && <ul id={aria_id} className="usa-nav__submenu">
       {
         pages.map((page) => {
           return <li className="usa-nav__submenu-item">
@@ -88,7 +88,7 @@ const AccordionNav = ({nav, pages}) => {
           </li>
         })
       }
-    </ul>: undefined}
+    </ul>}
   </li>
 }
 


### PR DESCRIPTION
Create a record in the CMS-page-builder table with type: nav. Set the title to be what you want the nav title to be. Set the "data" to be a comma-separated list of keys of "page" type records. Then it'll create a nested nav bar, with only those pages in the nav bar. All pages are still represented in the footer.