### PR TITLE
Add smart default for languages

### DIFF
--- a/utils/cms.js
+++ b/utils/cms.js
@@ -26,8 +26,10 @@ export function getRecordTitle(record, language = 'en') {
 * English:en,Spanish:es
 */
 export function getRecordLanguages(state) {
-  const options = getCmsRecordFromKey('languages', state).data.split(',');
-  if (!options) return [];
+  const languages = getCmsRecordFromKey('languages', state);
+  if (!languages.data)
+    return [{ name: 'English', key: 'en' }];
+  const options = languages.data.split(',');
   return options.map(option => {
     const data = option.split(':');
     return { name: data[0], key: data[1] };


### PR DESCRIPTION
Fixes: #11 

If someone does not have the `languages` key set in their CMS table (adding it to our default CMS linked in the github ASAP) it will fail.

This adds a check, and will return just English in the case that the CMS is missing this field