### PR TITLE
Index page as blocks

### DIFF
--- a/components/HeroWithButtons.jsx
+++ b/components/HeroWithButtons.jsx
@@ -18,8 +18,8 @@ const HeroWithButtons = ({ block }) => {
           <p>
             {block.body}
           </p>
-          {button_one.enabled && <Button href={button_one.href}>{button_one.body}</Button>}
-          {button_two.enabled && <Button href={button_two.href}>{button_two.body}</Button>}
+          {button_one?.enabled && <Button href={button_one.href}>{button_one.body}</Button>}
+          {button_two?.enabled && <Button href={button_two.href}>{button_two.body}</Button>}
         </div>
       </div>
     </div>

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -14,14 +14,19 @@ const List = ({ block }) => {
   return <section className="usa-section">
     <div className="grid-container">
       <h2> {block.title} </h2>
+      <div className="grid-row grid-gap-lg">
       {
         list_elements.map((el)=>{
-          return <p>
-            <a href={el.href}>{el.title}</a>
-          </p>
+          return <a href={el.href}
+              className="grid-col-4 height-card-lg text-center text-base-lightest font-sans-xl text-middle padding-105"
+              style={{ backgroundImage: `url(${el.image})`, backgroundSize: "cover",  backgroundClip: "content-box", textDecoration: "none" }}>
+            <div className="padding-5">
+              {el.title}
+            </div>
+          </a>
         })
       }
-
+      </div>
     </div>
   </section>
 }

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -1,0 +1,29 @@
+import React, { useContext } from 'react';
+import { CMSContext } from '../context/cms';
+import { getByTag } from '../utils/cms';
+import Button from '@/components/Button';
+
+const List = ({ block }) => {
+  let { state, dispatch } = useContext(CMSContext);
+
+  const list_elements = state.records.filter(record => {
+    return record.tag?.includes(block.key) && record.type == "list-element" && record.enabled;
+  });
+  console.log(list_elements);
+
+  return <section className="usa-section">
+    <div className="grid-container">
+      <h2> {block.title} </h2>
+      {
+        list_elements.map((el)=>{
+          return <p>
+            <a href={el.href}>{el.title}</a>
+          </p>
+        })
+      }
+
+    </div>
+  </section>
+}
+
+export default List;

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -17,10 +17,14 @@ const List = ({ block }) => {
       <div className="grid-row grid-gap-lg">
       {
         list_elements.map((el)=>{
-          return <a href={el.href}
-              className="grid-col-4 height-card-lg text-center text-base-lightest font-sans-xl text-middle padding-105"
-              style={{ backgroundImage: `url(${el.image})`, backgroundSize: "cover",  backgroundClip: "content-box", textDecoration: "none" }}>
-            <div className="padding-5">
+          return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
+                                              text-base-lightest font-sans-xl text-middle
+                                              padding-105 display-flex flex-justify-center
+                                              flex-align-center"
+                    style={{ backgroundImage: `url(${el.image})`,
+                             backgroundSize: "cover",  backgroundClip: "content-box",
+                             textDecoration: "none" }}>
+            <div>
               {el.title}
             </div>
           </a>

--- a/components/Text.jsx
+++ b/components/Text.jsx
@@ -1,5 +1,3 @@
-import Interweave from 'interweave';
-
 const Text = ({ block }) => (<section className="grid-container usa-section">
   <div className="grid-row grid-gap">
     {

--- a/layouts/neighbor.jsx
+++ b/layouts/neighbor.jsx
@@ -53,10 +53,12 @@ const NeighborLayout = ({ children }) => {
           {
             <RenderNavLinks key="nav" navs={nav} pages={pages} />
           }
-          <Link href="/request"><a className="usa-button" href="/request">
-            {cta.body}
-          </a>
-          </Link>
+          { cta &&
+            <Link href="/requests"><a className="usa-button" href="/requests">
+              {cta.body}
+            </a>
+            </Link>
+          }
         </nav>
       </div>
     </header>

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import Interweave from 'interweave';
 import { CMSContext } from '../context/cms';
-import { getCmsRecordFromKey } from '../utils/cms';
+import { getCmsRecordFromKey, getCmsBlocks, RenderCmsBlock } from '../utils/cms';
 import { getLayout } from '../layouts/neighbor.jsx';
 import Button from '@/components/Button';
 
@@ -15,61 +15,15 @@ const HomePage = () => {
   const button_one = getCmsRecordFromKey('hero_button_one', state);
   const button_two = getCmsRecordFromKey('hero_button_two', state);
 
-  return (
-    <>
-      <section aria-label="Introduction" id="hero">
-        <div className="usa-hero" style={{ backgroundImage: `url(${hero.image})` }}>
-          <div className="grid-container">
-            <div className="usa-hero__callout">
-              <h1 className="usa-hero__heading">
-                <span className="usa-hero__heading--alt">{hero.title}</span>
-              </h1>
-              <p>
-                {hero.body}
-              </p>
-              {button_one.enabled && <Button href={button_one.href}>{button_one.body}</Button>}
-              {button_two.enabled && <Button href={button_two.href}>{button_two.body}</Button>}
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="grid-container usa-section">
-        <div className="grid-row grid-gap">
-          <div className="tablet:grid-col-4">
-            <h2 className="font-heading-xl margin-bottom-2 tablet:margin-bottom-2">
-              {how.title}
-            </h2>
-          </div>
-          <div className="tablet:grid-col-8 usa-prose">
-            <div>
-              {how.body_markdown}
-            </div>
-          </div>
-        </div>
-      </section>
-      <section className="usa-section usa-section--dark">
-        <div className="grid-container">
-          <h2 className="font-heading-xl margin-y-0">{cta.title}</h2>
-          <Button href='/request' size='big'>{cta.body}</Button>
-        </div>
-      </section>
-      <section className="grid-container usa-section" id="currently_serving">
-        <div className="grid-row grid-gap">
-          <div className="tablet:grid-col-4">
-            <img src={serving.image} />
-          </div>
-          <div className="tablet:grid-col-8 usa-prose">
-            <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0">
-              {serving.title}
-            </h2>
-            <div>
-              {serving.body_markdown}
-            </div>
-          </div>
-        </div>
-      </section>
-    </>
-  );
+
+  let blocks = getCmsBlocks('home', state);
+
+  return <>
+    {blocks.map(block => (
+      <RenderCmsBlock key={block.key} block={block} />
+    ))}
+  </>
 };
+
 HomePage.getLayout = getLayout;
 export default HomePage;

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -49,7 +49,7 @@ export function getRecordLanguages(state) {
  */
 
 export function getCmsBlocks(page, state) {
-  return state.records.filter(record => { return record.tag?.includes(page); });
+  return state.records.filter(record => { return record.tag?.includes(page) && record.enabled; });
 }
 
 
@@ -149,12 +149,18 @@ export const RenderCmsElement = ({ Element }) => {
 export const getCmsRecordFromKey = (key, state) => {
   const { records, language } = state;
 
-  const record = records.filter(record => record.key === key)[0];
+  const filteredRecords = records.filter(record => record.key === key && record.enabled);
 
-  if (!record) {
+  if (filteredRecords.length == 0) {
     console.error(`❗ Missing ${key} value in CMS`, records);
-    return {};
+    return undefined;
   }
+
+  if (filteredRecords.length > 1) {
+    console.warn(`❗ Duplicate ${key} value in CMS, using first one`, records);
+  }
+
+  const record = filteredRecords[0];
 
   if (!record.key) {
     console.error(`The CMS was set up incorrectly and is missing a "key" column. Check that the column name is not "Name"!`);

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -5,6 +5,7 @@ import HeroWithButtons from '@/components/HeroWithButtons';
 import Form from '@/components/Form';
 import Button from '@/components/Button';
 import Quote from '@/components/Quote';
+import List from '@/components/List';
 import reactStringReplace from 'react-string-replace';
 import Link from 'next/link'
 import { useOnClickOutside } from "react-recipes";
@@ -130,6 +131,7 @@ export const RenderCmsBlock = ({ block }) => {
       'block-hero-button': <HeroWithButtons block={block} />,
       'block-form': <Form block={block} />,
       'block-quote': <Quote block={block} />,
+      'block-list': <List block={block} />,
     }[block.type]}</>
 }
 


### PR DESCRIPTION
- index page renders blocks with page = "home"
(I separately modified the staging airtable to have blocks which render the right things for the homepage)
- header CTA is now optional
- CMS now respects "enabled" field ~always