### PR TITLE
Genericize remaining hard-coded content

### DIFF
--- a/layouts/neighbor.jsx
+++ b/layouts/neighbor.jsx
@@ -15,7 +15,7 @@ const NeighborLayout = ({ children }) => {
   const title = getCmsRecordFromKey('title', state);
   const brand = getCmsRecordFromKey('brand', state);
   const cta = getCmsRecordFromKey('header_cta', state, false /*required*/);
-  const footer = getCmsRecordFromKey('contact', state);
+  const contact = getCmsRecordFromKey('contact', state);
   const languages = getRecordLanguages(state);
   const pages = getCmsPages(state);
   const nav = getCmsNav(state);
@@ -31,7 +31,7 @@ const NeighborLayout = ({ children }) => {
   return <div>
     <Head>
       <title>{title.title}</title>
-      <meta name="description" content="Request free meals, order your usual groceries, or ask for other help you may need. A volunteer will bring your delivery right to your door." />
+      <meta name="description" content={title.body} />
       <link id="favicon" rel="icon" href="https://glitch.com/favicon.ico" type="image/x-icon" />
       <meta charset="utf-8" />
       <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -83,16 +83,16 @@ const NeighborLayout = ({ children }) => {
             <div className="grid-row grid-gap">
               <div className="usa-footer__logo grid-row mobile-lg:grid-col-6 mobile-lg:grid-gap-2">
                 <div className="mobile-lg:grid-col-auto">
-                  <h3 className="usa-footer__logo-heading">Neighbor Express</h3>
+                  <h3 className="usa-footer__logo-heading">{brand.body}</h3>
                 </div>
               </div>
               <div className="usa-footer__contact-links mobile-lg:grid-col-6">
-                <h3 className="usa-footer__contact-heading">{footer.title}</h3>
+                <h3 className="usa-footer__contact-heading">{contact.title}</h3>
                 <address className="usa-footer__address">
                   <div className="usa-footer__contact-info grid-row grid-gap">
                     <div className="grid-col-auto">
                       <form className="usa-form">
-                        {footer.body}
+                        {contact.body}
                         <label className="usa-label" htmlFor="options">Choose Language</label>
                         <select onChange={(e) => setLanguage(e.target.value)} className="usa-select"
                                 name="options" id="options" value={state.language.key}>


### PR DESCRIPTION
Now, there's no content on our page that isn't controllable by the CMS
- page description is now pulling from "title" rather than hard coded
- name of the page in the footer matches name in the header (you usually don't see both at once, so this is fine)
- slight refactor to make the variable name "contact" less confusing.