### PR TITLE
Blocks can now be marked as compact and have less margin

### DIFF
--- a/components/Columns.jsx
+++ b/components/Columns.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { CMSContext } from '../context/cms';
 import Button from '@/components/Button';
+import Content from '@/components/Content';
 
 
 const Columns = ({ block }) => {
@@ -11,7 +12,7 @@ const Columns = ({ block }) => {
   });
 
 
-  return <section className="grid-container usa-section">
+  return <Content block={block}>
     <div className="grid-row grid-gap">
       {
         columns.map((column) => {
@@ -27,7 +28,7 @@ const Columns = ({ block }) => {
         })
       }
     </div>
-  </section>
+  </Content>
 }
 
 

--- a/components/Content.jsx
+++ b/components/Content.jsx
@@ -1,0 +1,10 @@
+var classNames = require('classnames');
+
+const Content = ({block, children}) => {
+	const classes = classNames("grid-container", {"usa-section": !block.compact})
+	return <section aria-label={block.title} className={classes}>
+		{children}
+	</section>
+}
+
+export default Content;

--- a/components/Form.jsx
+++ b/components/Form.jsx
@@ -1,5 +1,6 @@
+import Content from '@/components/Content';
 
-const Form = ({ block }) => (<section className="grid-container usa-section">
+const Form = ({ block }) => (<Content block={block}>
   <div className="grid-row grid-gap">
     <div className="tablet:grid-col-12 usa-prose">
       <h2 className="font-heading-xl margin-top-0 tablet:margin-bottom-0">
@@ -10,7 +11,7 @@ const Form = ({ block }) => (<section className="grid-container usa-section">
       </section>
     </div>
   </div>
-</section>);
+</Content>);
 
 
 export default Form;

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import { CMSContext } from '../context/cms';
 import { getByTag } from '../utils/cms';
 import Button from '@/components/Button';
+import Content from '@/components/Content';
 
 const List = ({ block }) => {
   let { state, dispatch } = useContext(CMSContext);
@@ -10,29 +11,27 @@ const List = ({ block }) => {
     return record.tag?.includes(block.key) && record.type == "list-element" && record.enabled;
   });
 
-  return <section className="usa-section">
-    <div className="grid-container">
-      <h2> {block.title} </h2>
-      <div className="grid-row grid-gap-lg">
-      {
-        list_elements.map((el)=>{
-          return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
-                                              text-base-lightest font-sans-xl text-middle
-                                              padding-105 display-flex flex-justify-center
-                                              flex-align-center"
-                    style={{ backgroundImage: `url(${el.image})`,
-                             backgroundSize: "cover",  backgroundClip: "content-box",
-                             textDecoration: "none" }}
-                    key={el.key}>
-            <div>
-              {el.title}
-            </div>
-          </a>
-        })
-      }
-      </div>
+  return <Content block={block}>
+    <h2> {block.title} </h2>
+    <div className="grid-row grid-gap-lg">
+    {
+      list_elements.map((el)=>{
+        return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
+                                            text-base-lightest font-sans-xl text-middle
+                                            padding-105 display-flex flex-justify-center
+                                            flex-align-center"
+                  style={{ backgroundImage: `url(${el.image})`,
+                           backgroundSize: "cover",  backgroundClip: "content-box",
+                           textDecoration: "none" }}
+                  key={el.key}>
+          <div>
+            {el.title}
+          </div>
+        </a>
+      })
+    }
     </div>
-  </section>
+  </Content>
 }
 
 export default List;

--- a/components/Photo.jsx
+++ b/components/Photo.jsx
@@ -1,8 +1,10 @@
-const Photo = ({ block }) => (<section className="grid-container usa-section">
+import Content from '@/components/Content';
+
+const Photo = ({ block }) => (<Content block={block}>
   <div className="grid-row">
     <img src={block.image} alt={block.body} />
   </div>
-</section>
+</Content>
 )
 
 export default Photo;

--- a/components/Text.jsx
+++ b/components/Text.jsx
@@ -1,4 +1,6 @@
-const Text = ({ block }) => (<section className="grid-container usa-section">
+import Content from '@/components/Content';
+
+const Text = ({ block }) => (<Content block={block}>
   <div className="grid-row grid-gap">
     {
       block.image && !block.data?.includes('image:right') &&
@@ -21,9 +23,7 @@ const Text = ({ block }) => (<section className="grid-container usa-section">
       </div>
     }
   </div>
-</section>
+</Content>
 )
-
-
 
 export default Text;

--- a/components/YouTube.jsx
+++ b/components/YouTube.jsx
@@ -1,36 +1,35 @@
-// regex the href so its foolproof
+import Content from '@/components/Content';
 
 const YouTube = ({ block }) => {
+  // regex the href so its foolproof
   // https://stackoverflow.com/questions/3717115/regular-expression-for-youtube-links
   const regexp = /(?:https?:\/\/)?(?:www\.)?youtu\.?be(?:\.com)?\/?.*(?:watch|embed)?(?:.*v=|v\/|\/)([\w-_]+)/
   const match = regexp.exec(block.href);
   const youtube_id = match && match.length > 1 ? match[1] : "";
   
-  return <section className="usa-section usa-section">
-    <div className="grid-container">
-      { block.title && <h2 className="font-heading-xl margin-y-0">{block.title}</h2> }
-      { block.body_markdown && <div> {block.body_markdown} </div> }
-      <div className="videoWrapper">
-      	<iframe src={`https://www.youtube.com/embed/${youtube_id}`} frameBorder="0" allowFullScreen
-      			allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"></iframe>
-      </div>
+  return <Content block={block}>
+    { block.title && <h2 className="font-heading-xl margin-y-0">{block.title}</h2> }
+    { block.body_markdown && <div> {block.body_markdown} </div> }
+    <div className="videoWrapper">
+    	<iframe src={`https://www.youtube.com/embed/${youtube_id}`} frameBorder="0" allowFullScreen
+    			allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"></iframe>
     </div>
-	{/* https://css-tricks.com/fluid-width-video/ */}
+    {/* https://css-tricks.com/fluid-width-video/ */}
     <style jsx>{`
-	.videoWrapper {
-	  position: relative;
-	  padding-bottom: 56.25%; /* 16:9 */
-	  height: 0;
-	}
-	.videoWrapper iframe {
-	  position: absolute;
-	  top: 0;
-	  left: 0;
-	  width: 100%;
-	  height: 100%;
-	}
-  `}</style>
-  </section>
+      .videoWrapper {
+        position: relative;
+        padding-bottom: 56.25%; /* 16:9 */
+        height: 0;
+      }
+      .videoWrapper iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+    `}</style>
+  </Content>
 }
 
 export default YouTube;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2238,6 +2238,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@actions/exec": "^1.0.3",
     "airtable": "^0.8.1",
     "airtable-plus": "^1.0.4",
+    "classnames": "^2.2.6",
     "interweave": "^12.5.0",
     "markdown-to-jsx": "^6.11.1",
     "next": "^9.3.5",


### PR DESCRIPTION
## Links
* Issue link: https://github.com/usdigitalresponse/neighbor-express/issues/35

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/3465150/80753095-8ad96880-8ae1-11ea-9af6-072c1c175eab.png)
(note the reduced space between the image and the text)

## Changes:
* Some blocks can be marked as "compact", and then they have less margin so they're not awkwardly far apart
* Refactors to share code for the "compact" logic using a <Content> component
* "compact" is a no-op for some blocks (hero, hero with buttons, quote) because it doesn't make sense because they don't have white backgrounds. So it'd look squished

## How To Test:
* Add a boolean "compact" column to your airtable. Test marking some blocks as compact and observing the less margin
- Form
- Text
- Photo
- Youtube
- Columns
- List

## Feedback I'm looking for:
Do you think this approach to controlling the spacing will give users sufficient flexibility?

## Things left to do before deploying:
- [ ] N/A, this should be a no/op change if your CMS-page-builder does not have a "compact" column
