### PR TITLE
If a column has an href, its image links to the href.

### DIFF
--- a/components/Columns.jsx
+++ b/components/Columns.jsx
@@ -13,11 +13,18 @@ const Columns = ({ block }) => {
 
 
   return <Content block={block}>
+    <h2> {block.title} </h2>
     <div className="grid-row grid-gap">
       {
         columns.map((column) => {
+          const imageElement = column.image && column.href ?
+            <a href={column.href}>
+              <img src={column.image}/>
+            </a> :
+            <img src={column.image}/>
+
           return <div className="tablet:grid-col" key={column.key}>
-            {column.image && <img src={column.image} />}
+            {column.image && imageElement}
             {column.title && <h3 className="font-heading-xl margin-top-0 tablet:margin-bottom-0">
               {column.title}
             </h3>}


### PR DESCRIPTION
To be used for external links only, relative links won't really work (similar to List block)

## Links
* Issue link
* Documentation links

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/3465150/80840646-921c7700-8bb2-11ea-81ca-3ef71a840e6e.png)
These are all now links to the partners

## Changes:
* If you add an href to a column's airtable row, and there's an image, the image links to the href
* If you add a title to the block-columns row, that title shows up above/across all the columns (this is a feature block-list already has)
* does not include image alt text, will add that in a separate change

## How To Test:
* I've added the sponsors content to staging to play around with. https://airtable.com/tblvxThOiOkv8oIPE/viwKhPFWXJmqznfsW?blocks=hide and the preview link in this PR
* test that it works as expected with different combinations of image (present/absent) href (present/absent) body and title.

## Feedback I'm looking for:
* will this work for our sponsors use case?

## Things left to do before deploying:
- [ ] ...
