### PR TITLE
All inline images have alt text

### DIFF
--- a/components/Columns.jsx
+++ b/components/Columns.jsx
@@ -19,9 +19,9 @@ const Columns = ({ block }) => {
         columns.map((column) => {
           const imageElement = column.image && column.href ?
             <a href={column.href}>
-              <img src={column.image}/>
+              <img src={column.image} alt={column.alt}/>
             </a> :
-            <img src={column.image}/>
+            <img src={column.image} alt={column.alt}/>
 
           return <div className="tablet:grid-col" key={column.key}>
             {column.image && imageElement}

--- a/components/Photo.jsx
+++ b/components/Photo.jsx
@@ -2,7 +2,7 @@ import Content from '@/components/Content';
 
 const Photo = ({ block }) => (<Content block={block}>
   <div className="grid-row">
-    <img src={block.image} alt={block.body} />
+    <img src={block.image} alt={block.alt} />
   </div>
 </Content>
 )

--- a/components/Text.jsx
+++ b/components/Text.jsx
@@ -5,7 +5,7 @@ const Text = ({ block }) => (<Content block={block}>
     {
       block.image && !block.data?.includes('image:right') &&
       <div className="tablet:grid-col-4">
-        <img src={block.image} />
+        <img src={block.image} alt={block.alt}/>
       </div>
     }
     <div className="tablet:grid-col-8 usa-prose">
@@ -19,7 +19,7 @@ const Text = ({ block }) => (<Content block={block}>
     {
       block.image && block.data?.includes('image:right') &&
       <div className="tablet:grid-col-4">
-        <img src={block.image} />
+        <img src={block.image} alt={block.alt} />
       </div>
     }
   </div>

--- a/utils/cms.js
+++ b/utils/cms.js
@@ -14,23 +14,14 @@ import Link from 'next/link'
 import { useOnClickOutside } from "react-recipes";
 import Markdown from 'markdown-to-jsx';
 
-/**
-* Outputs the body of a record depending on the language of the user
-* and then formats it with a markdown processor
-* Defaults to english
-*/
-export function getRecordBody(record, language = 'en') {
-  const body = record[`body_${language}`] || record[`body_en`];
-  return body;
-}
 
 /**
-* Outputs the title of a record depending on the language of the user
+* Outputs the requested field of a record depending on the language of the user
 * Defaults to english
 */
-export function getRecordTitle(record, language = 'en') {
-  const title = record[`title_${language}`] || record[`title`];
-  return title;
+function getRecordField (record, fieldName, language = 'en') {
+  const field = record[`${fieldName}_${language}`] || record[`${fieldName}`];
+  return field;
 }
 
 /** 
@@ -188,9 +179,10 @@ export const processRecords = (records, state) => {
   return records.map(record => {
     // We're going to make a helper for the picture column
     record.image = record.picture[0]?.url;
-    record.body = getRecordBody(record, language);
+    record.body = getRecordField(record, 'body', language);
     record.body_markdown = <Markdown>{record.body || ""}</Markdown>;
-    record.title = getRecordTitle(record, language);
+    record.title = getRecordField(record, 'title', language);
+    record.alt = getRecordField(record, 'alt', language);
     return record;
   });
 }


### PR DESCRIPTION
## GIF/Screenshots:

## Changes:
* Text, Photo, and Column block images now have alt text. They use the alt_(language code) columns (so no awkward duplication with body text, in case the body you want doesn't actually describe the image visually)
* does not apply to List or Hero blocks because those are using background images which can't have alt text... we should think about that

## How To Test:
* Using the staging airtable https://airtable.com/tblvxThOiOkv8oIPE/viwKhPFWXJmqznfsW?blocks=hide and the preview link generated in this PR. Add the alt text you want to the alt_en or alt_es columns. Check that alt text is appearing on images in Text, Column, and Photo blocks. Check that changing language on the page also changes the language of the alt text.

## Feedback I'm looking for:
* any ideas on how to make this foolproof / make sure we don't forget to add alt text on features we build in the future?

## Things left to do before deploying:
- [ x] add alt_en and alt_es columns to all our partner sites, landing page and staging
- [ ] for every photo, provide an alt text description for screen reader accessibility
