### PR TITLE
Favicon now controllable by CMS

### DIFF
--- a/layouts/neighbor.jsx
+++ b/layouts/neighbor.jsx
@@ -32,7 +32,7 @@ const NeighborLayout = ({ children }) => {
     <Head>
       <title>{title.title}</title>
       <meta name="description" content={title.body} />
-      <link id="favicon" rel="icon" href="https://glitch.com/favicon.ico" type="image/x-icon" />
+      {title.image && <link id="favicon" rel="icon" href={title.image} type="image/x-icon" />}
       <meta charset="utf-8" />
       <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/3465150/81022470-8cc56380-8e22-11ea-90e5-1f8ed1dd3a86.png)

## Changes:
* Favicon didn't work before. Now it shows whatever's in the "picture" column of the "title" row in airtable.

## How To Test:
* Works with staging airtable and the preview link generated in this PR

## Feedback I'm looking for:

## Things left to do before deploying:
- [ ] ...
