### PR TITLE
Add snapshot testing of all simple components

### DIFF
--- a/components/Form.jsx
+++ b/components/Form.jsx
@@ -1,4 +1,4 @@
-import Content from '@/components/Content';
+import Content from './Content';
 
 const Form = ({ block }) => (<Content block={block}>
   <div className="grid-row grid-gap">

--- a/components/Photo.jsx
+++ b/components/Photo.jsx
@@ -1,4 +1,4 @@
-import Content from '@/components/Content';
+import Content from './Content';
 
 const Photo = ({ block }) => (<Content block={block}>
   <img src={block.image} alt={block.alt} />

--- a/components/Quote.jsx
+++ b/components/Quote.jsx
@@ -1,4 +1,4 @@
-import Button from '@/components/Button';
+import Button from './Button';
 
 const Quote = ({ block }) => (
   <section className="usa-section usa-section--dark">

--- a/components/YouTube.jsx
+++ b/components/YouTube.jsx
@@ -1,4 +1,4 @@
-import Content from '@/components/Content';
+import Content from './Content';
 
 const YouTube = ({ block }) => {
   // regex the href so its foolproof

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   setupFiles: ['<rootDir>/jest.setup.js'],
-  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/']
+  testPathIgnorePatterns: ['<rootDir>/.next/', '<rootDir>/node_modules/'],
+	snapshotSerializers: ['enzyme-to-json/serializer']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4361,6 +4361,24 @@
         "object-is": "^1.0.2"
       }
     },
+    "enzyme-to-json": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.4.tgz",
+      "integrity": "sha512-50LELP/SCPJJGic5rAARvU7pgE3m1YaNj7JLM+Qkhl5t7PAs6fiyc8xzc50RnkKPFQCv0EeFVjEWdIFRGPWMsA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.4.4",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/tests/Button.test.js
+++ b/tests/Button.test.js
@@ -1,0 +1,18 @@
+import { shallow } from "enzyme";
+import Button from "../components/Button.jsx";
+
+let wrapper;
+
+beforeEach(() => {
+  wrapper = shallow(
+    <Button href='/volunteer'>
+      Volunteer now!!
+    </Button>
+  );
+});
+
+describe("Button component", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/Form.test.js
+++ b/tests/Form.test.js
@@ -1,0 +1,19 @@
+import { shallow } from "enzyme";
+import Form from "../components/Form.jsx";
+
+let wrapper;
+
+const block = {
+  title: 'Test title',
+  body: 'abc123airtableformcode'
+};
+
+beforeEach(() => {
+  wrapper = shallow( <Form block={block} />);
+});
+
+describe("Form block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/Hero.test.js
+++ b/tests/Hero.test.js
@@ -1,0 +1,20 @@
+import { shallow } from "enzyme";
+import Hero from "../components/Hero.jsx";
+
+let wrapper;
+
+const block = {
+  title: 'Test title',
+  body: 'Test body',
+  image: 'https://icatcare.org/app/uploads/2019/09/The-Kitten-Checklist-1.png'
+};
+
+beforeEach(() => {
+  wrapper = shallow( <Hero block={block} />);
+});
+
+describe("Hero block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/Photo.test.js
+++ b/tests/Photo.test.js
@@ -1,0 +1,21 @@
+import { shallow } from "enzyme";
+import Photo from "../components/Photo.jsx";
+
+let wrapper;
+
+const block = {
+  title: 'Test title',
+  body_markdown: 'Test body',
+  image: 'https://cdn2-www.dogtime.com/assets/uploads/2011/03/puppy-development.jpg',
+  alt: 'golden retriever puppy'
+};
+
+beforeEach(() => {
+  wrapper = shallow( <Photo block={block} />);
+});
+
+describe("Photo block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/Quote.test.js
+++ b/tests/Quote.test.js
@@ -1,0 +1,20 @@
+import { shallow } from "enzyme";
+import Quote from "../components/Quote.jsx";
+
+let wrapper;
+
+const block = {
+  title: 'May the Force be with you',
+  body: 'Btn text',
+  href: 'www.google.com'
+};
+
+beforeEach(() => {
+  wrapper = shallow( <Quote block={block} />);
+});
+
+describe("Quote block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# How to Test
+
+`npm run test` will run all the tests locally. You may need to `npm install` first.
+
+All tests also run in a git hook on every `git push` of every branch and the results show up as comments on the pull request.
+
+If you make an intentional change to a component, but don't update the snapshots to reflect that intentional change, the snapshot tests will probably fail! To fix that, run 
+
+`npm run test -- -u`
+
+which will regenerate the snapshots. (Make sure you only do this when you know the feature is working, or the test will be guaranteeing the incorrect behavior!). Updated snapshots should be checked into git and reviewed like all other code.
+

--- a/tests/Text.test.js
+++ b/tests/Text.test.js
@@ -1,20 +1,28 @@
 import { shallow } from "enzyme";
 import Text from "../components/Text.jsx";
 
-describe("Text block", () => {
-	const block = {
-		title: 'aaa',
-		body_markdown: 'bbb',
-	}
-	it('shows header', () => {
-    const text = shallow(<Text block={block} />);
+let wrapper;
 
-    expect(text.find("h2").text()).toEqual("aaa");
+const block = {
+  title: 'aaa',
+  body_markdown: 'bbb',
+};
+
+beforeEach(() => {
+  wrapper = shallow(<Text block={block} />);
+});
+
+describe("Text block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+
+	it('shows header', () => {
+    expect(wrapper.find("h2").text()).toEqual("aaa");
   });
 
   it('shows body', () => {
-    const text = shallow(<Text block={block} />);
-    expect(text.contains(<div>bbb</div>)).toEqual(true);
+    expect(wrapper.contains(<div>bbb</div>)).toEqual(true);
   });
 
   it('shows image', () => {

--- a/tests/YouTube.test.js
+++ b/tests/YouTube.test.js
@@ -1,0 +1,20 @@
+import { shallow } from "enzyme";
+import YouTube from "../components/YouTube.jsx";
+
+let wrapper;
+
+const block = {
+  title: 'Test title',
+  body_markdown: 'Test body',
+  href: 'https://youtu.be/NzwSF9GEm0E'
+};
+
+beforeEach(() => {
+  wrapper = shallow( <YouTube block={block} />);
+});
+
+describe("YouTube block", () => {
+  it('renders correctly', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/__snapshots__/Button.test.js.snap
+++ b/tests/__snapshots__/Button.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button component renders correctly 1`] = `
+<p>
+  <Link
+    as="/volunteer"
+    href="/[pid]"
+  >
+    <a
+      className="usa-button usa-button--small"
+      href="/volunteer"
+    >
+      Volunteer now!!
+    </a>
+  </Link>
+</p>
+`;

--- a/tests/__snapshots__/Form.test.js.snap
+++ b/tests/__snapshots__/Form.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Form block renders correctly 1`] = `
+<Content
+  block={
+    Object {
+      "body": "abc123airtableformcode",
+      "title": "Test title",
+    }
+  }
+>
+  <div
+    className="grid-row grid-gap"
+  >
+    <div
+      className="tablet:grid-col-12 usa-prose"
+    >
+      <h2
+        className="font-heading-xl margin-top-0 tablet:margin-bottom-0"
+      >
+        Test title
+      </h2>
+      <section
+        id="request_form"
+      >
+        <iframe
+          className="airtable-embed airtable-dynamic-height"
+          frameBorder="0"
+          height="2316"
+          onmousewheel=""
+          src="https://airtable.com/embed/abc123airtableformcode"
+          width="100%"
+        />
+      </section>
+    </div>
+  </div>
+</Content>
+`;

--- a/tests/__snapshots__/Hero.test.js.snap
+++ b/tests/__snapshots__/Hero.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Hero block renders correctly 1`] = `
+<section
+  aria-label="Introduction"
+>
+  <div
+    className="usa-hero"
+    style={
+      Object {
+        "backgroundImage": "url(https://icatcare.org/app/uploads/2019/09/The-Kitten-Checklist-1.png)",
+      }
+    }
+  >
+    <div
+      className="grid-container"
+    >
+      <div
+        className="usa-hero__callout"
+      >
+        <h1
+          className="usa-hero__heading"
+        >
+          <span
+            className="usa-hero__heading--alt"
+          >
+            Test title
+          </span>
+        </h1>
+        <div>
+          Test body
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+`;

--- a/tests/__snapshots__/Photo.test.js.snap
+++ b/tests/__snapshots__/Photo.test.js.snap
@@ -11,13 +11,9 @@ exports[`Photo block renders correctly 1`] = `
     }
   }
 >
-  <div
-    className="grid-row"
-  >
-    <img
-      alt="golden retriever puppy"
-      src="https://cdn2-www.dogtime.com/assets/uploads/2011/03/puppy-development.jpg"
-    />
-  </div>
+  <img
+    alt="golden retriever puppy"
+    src="https://cdn2-www.dogtime.com/assets/uploads/2011/03/puppy-development.jpg"
+  />
 </Content>
 `;

--- a/tests/__snapshots__/Photo.test.js.snap
+++ b/tests/__snapshots__/Photo.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Photo block renders correctly 1`] = `
+<Content
+  block={
+    Object {
+      "alt": "golden retriever puppy",
+      "body_markdown": "Test body",
+      "image": "https://cdn2-www.dogtime.com/assets/uploads/2011/03/puppy-development.jpg",
+      "title": "Test title",
+    }
+  }
+>
+  <div
+    className="grid-row"
+  >
+    <img
+      alt="golden retriever puppy"
+      src="https://cdn2-www.dogtime.com/assets/uploads/2011/03/puppy-development.jpg"
+    />
+  </div>
+</Content>
+`;

--- a/tests/__snapshots__/Quote.test.js.snap
+++ b/tests/__snapshots__/Quote.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Quote block renders correctly 1`] = `
+<section
+  className="usa-section usa-section--dark"
+>
+  <div
+    className="grid-container"
+  >
+    <h2
+      className="font-heading-xl margin-y-0"
+    >
+      May the Force be with you
+    </h2>
+    <Button
+      href="www.google.com"
+      size="big"
+    >
+      Btn text
+    </Button>
+  </div>
+</section>
+`;

--- a/tests/__snapshots__/Text.test.js.snap
+++ b/tests/__snapshots__/Text.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text block renders correctly 1`] = `
+<Content
+  block={
+    Object {
+      "body_markdown": "bbb",
+      "title": "aaa",
+    }
+  }
+>
+  <div
+    className="grid-row grid-gap"
+  >
+    <div
+      className="tablet:grid-col-8 usa-prose"
+    >
+      <h2
+        className="font-heading-xl margin-top-0 tablet:margin-bottom-0"
+      >
+        aaa
+      </h2>
+      <div>
+        bbb
+      </div>
+    </div>
+  </div>
+</Content>
+`;

--- a/tests/__snapshots__/YouTube.test.js.snap
+++ b/tests/__snapshots__/YouTube.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`YouTube block renders correctly 1`] = `
+<Content
+  block={
+    Object {
+      "body_markdown": "Test body",
+      "href": "https://youtu.be/NzwSF9GEm0E",
+      "title": "Test title",
+    }
+  }
+>
+  <h2
+    className="jsx-2037020011 font-heading-xl margin-y-0"
+  >
+    Test title
+  </h2>
+  <div
+    className="jsx-2037020011"
+  >
+     
+    Test body
+     
+  </div>
+  <div
+    className="jsx-2037020011 videoWrapper"
+  >
+    <iframe
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen={true}
+      className="jsx-2037020011"
+      frameBorder="0"
+      src="https://www.youtube.com/embed/NzwSF9GEm0E"
+    />
+  </div>
+  <JSXStyle
+    id="2037020011"
+  >
+    .videoWrapper.jsx-2037020011{position:relative;padding-bottom:56.25%;height:0;}.videoWrapper.jsx-2037020011 iframe.jsx-2037020011{position:absolute;top:0;left:0;width:100%;height:100%;}
+  </JSXStyle>
+</Content>
+`;


### PR DESCRIPTION
## Changes:
* adds snapshot testing using jest and enzyme. Makes sure element rendering doesn't change unless we want it to.

## How To Test:
* `npm run test`
and if you want to regenerate the snapshots (intentional change to the component)
* `./node_modules/.bin/jest --updateSnapshot`

## Feedback I'm looking for:

## Things left to do before deploying:
- [ ] ...
