### PR TITLE
Add overlays on city names

### DIFF
--- a/components/List.jsx
+++ b/components/List.jsx
@@ -17,14 +17,14 @@ const List = ({ block }) => {
     {
       list_elements.map((el)=>{
         return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
-                                            text-base-lightest font-sans-xl text-middle
+                                            font-sans-xl text-middle
                                             padding-105 display-flex flex-justify-center
                                             flex-align-center"
                   style={{ backgroundImage: `url(${el.image})`,
                            backgroundSize: "cover",  backgroundClip: "content-box",
                            textDecoration: "none" }}
                   key={el.key}>
-          <div>
+          <div style={{background: "black", opacity: 0.7, padding: "1rem 0.5rem", color: "white"}}>
             {el.title}
           </div>
         </a>

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -17,14 +17,14 @@ const List = ({ block }) => {
     {
       list_elements.map((el)=>{
         return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
-                                            font-sans-xl text-middle
-                                            padding-105 display-flex flex-justify-center
-                                            flex-align-center"
+                                            font-sans-lg text-semibold padding-105"
                   style={{ backgroundImage: `url(${el.image})`,
                            backgroundSize: "cover",  backgroundClip: "content-box",
                            textDecoration: "none" }}
                   key={el.key}>
-          <div style={{background: "black", opacity: 0.7, padding: "1rem 0.5rem", color: "white"}}>
+          <div className="display-flex flex-justify-start flex-align-end padding-2"
+               style={{ height: "100%", width: "100%", color: "white",
+                        backgroundImage: 'linear-gradient(rgba(0,0,0,0), rgba(0,0,0,1))'}}>
             {el.title}
           </div>
         </a>

--- a/components/List.jsx
+++ b/components/List.jsx
@@ -3,6 +3,9 @@ import { CMSContext } from '../context/cms';
 import { getByTag } from '../utils/cms';
 import Button from '@/components/Button';
 import Content from '@/components/Content';
+import styles from './List.module.css'
+var classNames = require('classnames');
+
 
 const List = ({ block }) => {
   let { state, dispatch } = useContext(CMSContext);
@@ -11,20 +14,19 @@ const List = ({ block }) => {
     return record.tag?.includes(block.key) && record.type == "list-element" && record.enabled;
   });
 
+  const imageLinkClasses = classNames(styles.image, "tablet:grid-col-4",
+    "height-card-lg", "font-sans-lg", "text-semibold", "padding-105");
+  const overlayClasses = classNames(styles.overlay, "display-flex",
+    "flex-justify-start", "flex-align-end", "padding-2");
+
   return <Content block={block}>
     <h2> {block.title} </h2>
     <div className="grid-row grid-gap-lg">
     {
       list_elements.map((el)=>{
-        return <a href={el.href} className="tablet:grid-col-4 height-card-lg text-center
-                                            font-sans-lg text-semibold padding-105"
-                  style={{ backgroundImage: `url(${el.image})`,
-                           backgroundSize: "cover",  backgroundClip: "content-box",
-                           textDecoration: "none" }}
-                  key={el.key}>
-          <div className="display-flex flex-justify-start flex-align-end padding-2"
-               style={{ height: "100%", width: "100%", color: "white",
-                        backgroundImage: 'linear-gradient(rgba(0,0,0,0), rgba(0,0,0,1))'}}>
+        return <a href={el.href} className={imageLinkClasses}
+                  style={{  backgroundImage: `url(${el.image})`}} key={el.key}>
+          <div className={overlayClasses}>
             {el.title}
           </div>
         </a>

--- a/components/List.module.css
+++ b/components/List.module.css
@@ -1,0 +1,13 @@
+.image {
+	background-image: `url(${el.image})`;
+	background-size: cover;
+	background-clip: content-box;
+	text-decoration: none;
+}
+
+.overlay {
+	height: 100%;
+	width: 100%;
+	color: white;
+  background-image: linear-gradient(rgba(0,0,0,0), rgba(0,0,0,0.75));
+}


### PR DESCRIPTION
## Links
* Issue link
* Documentation links

## GIF/Screenshots:
![image](https://user-images.githubusercontent.com/3465150/81239250-1f980680-8fb9-11ea-99a1-355c2882a9e5.png)

## Changes:
* add background behind text over the picture so that you can read it better

## How To Test:
* This will appear for any list component.

## Feedback I'm looking for:
... I don't really think this looks that good? Especially because it varies in size with the content? can I get some design feedback on this?

## Things left to do before deploying:
- [ ] ...
