### PR TITLE
Fix photo width

### DIFF
--- a/components/Photo.jsx
+++ b/components/Photo.jsx
@@ -1,9 +1,7 @@
 import Content from '@/components/Content';
 
 const Photo = ({ block }) => (<Content block={block}>
-  <div className="grid-row">
-    <img src={block.image} alt={block.alt} />
-  </div>
+  <img src={block.image} alt={block.alt} />
 </Content>
 )
 

--- a/utils/airtable.js
+++ b/utils/airtable.js
@@ -8,7 +8,7 @@ async function getCms(baseId, apiKey) {
   });
 
   const records = await inst.read({
-    maxRecords: 100, sort: [{
+    sort: [{
       field: 'key', direction: 'asc'
     }]
   });


### PR DESCRIPTION
## Links
* Issue link https://github.com/usdigitalresponse/neighbor-express/issues/116

## GIF/Screenshots:
Before:
<img width="781" alt="Screenshot 2020-05-09 15 09 11" src="https://user-images.githubusercontent.com/3465150/81486118-72ff9400-9207-11ea-93ae-53b8fadb4911.png">
After:
![image](https://user-images.githubusercontent.com/3465150/81486124-801c8300-9207-11ea-80b6-ba61d396521a.png)


## Changes:
Looks like the issue was happening on Safari, but not Chrome. As I develop on Chrome, I wasn't seeing this issue. This https://stackoverflow.com/questions/56927639/images-are-squishing-vertically-on-iphone-8-chrome-safari gave me the clue that it was the flex behavior of grid-row that was causing the issue. Well, we don't care about grid-row for the photo block so, we can get rid of it. Love when you can fix a bug by deleting some code!

Also removes the max records limit, if you have too many rows in your airtable it'll probably be slow, but limiting the number we download is actually worse because some of your content will just randomly not show up.

## How To Test:
* would love help testing on a variety of browsers

## Feedback I'm looking for:

## Things left to do before deploying:
- [ ] ...
