### PR TITLE
move demo3 to the front of the array

### DIFF
--- a/scripts/update-all.js
+++ b/scripts/update-all.js
@@ -2,7 +2,7 @@ const exec = require('@actions/exec');
 const populateCmsCache = require('./populate-cms-cache.js');
 
 // What cities do we serve?
-const cities = ['concord', 'walnutcreek', 'paterson', 'demo1', 'demo2', 'demo3', 'cms', 'landing-page'];
+const cities = ['demo3', 'concord', 'walnutcreek', 'paterson', 'demo1', 'demo2', 'cms', 'landing-page'];
 
 //https://codeburst.io/javascript-async-await-with-foreach-b6ba62bbf404
 async function asyncForEach(array, callback) {


### PR DESCRIPTION
## Links
* #131 for this fix

## GIF/Screenshots:

## Changes:
* Moves `demo3` to the front of the array, so it'll absorb the flakiness and concord should get assigned the right site.

I'll make a second ticket for work to fix this flakiness overall after this is deployed