### PR TITLE
[WIP] Volunteer emails

### DIFF
--- a/send_email_messages/.block/delaware.remote.json
+++ b/send_email_messages/.block/delaware.remote.json
@@ -1,0 +1,4 @@
+{
+    "baseId": "appNGpIO3xRuiceJe",
+    "blockId": "blklON2HBOv5b3wYb"
+}

--- a/send_email_messages/frontend/refresh-queue.js
+++ b/send_email_messages/frontend/refresh-queue.js
@@ -118,11 +118,15 @@ async function computeVolunteerWelcomeMessages() {
           "Email type": { name: EMAIL_TYPE_NAME },
           Status: { name: "Queued" },
           Recipient: volunteer.getCellValue("Email"),
-          "Template Data": "{}", // todo: do we need to template any data here?
+          "Template Data": JSON.stringify({
+            volunteer: {
+              name: volunteer.getCellValue("Full Name"),
+            },
+          }),
         },
       });
     } else {
-      warnings.push(
+      output.warnings.push(
         `Missing email for volunteer: ${volunteer.getCellValue("Full Name")}`
       );
     }

--- a/send_email_messages/frontend/refresh-queue.js
+++ b/send_email_messages/frontend/refresh-queue.js
@@ -122,7 +122,9 @@ async function computeVolunteerWelcomeMessages() {
         },
       });
     } else {
-      // TODO: add a warning about missing email
+      warnings.push(
+        `Missing email for volunteer: ${volunteer.getCellValue("Full Name")}`
+      );
     }
   }
 

--- a/send_email_messages/frontend/send-messages.js
+++ b/send_email_messages/frontend/send-messages.js
@@ -16,6 +16,20 @@ async function sendMessage(messageToSend) {
     messageToSend.getCellValue("Template Data")
   );
   const EMAIL_TYPES = globalConfig.get("email_types");
+
+  let templateId;
+  if (
+    messageToSend.getCellValue("Email type") ===
+    "Initial Confirmation: Volunteer"
+  ) {
+    templateId =
+      EMAIL_TYPES[messageToSend.getCellValue("Email type").name][
+        "sendgrid_template"
+      ];
+  } else {
+    templateId = globalConfig.get("volunteer_welcome_email_template_id");
+  }
+
   const sendgridData = {
     personalizations: [
       {
@@ -32,10 +46,7 @@ async function sendMessage(messageToSend) {
       email: "noreply@neighborexpress.org",
     },
     reply_to: globalConfig.get("reply_to"),
-    template_id:
-      EMAIL_TYPES[messageToSend.getCellValue("Email type").name][
-        "sendgrid_template"
-      ],
+    template_id: templateId,
   };
   const token = globalConfig.get("SENDGRID_PROXY_TOKEN");
   const response = await fetch(

--- a/send_email_messages/frontend/settings.js
+++ b/send_email_messages/frontend/settings.js
@@ -9,6 +9,7 @@ import {
   InputSynced,
   SelectButtonsSynced,
   SelectSynced,
+  Switch,
   Text,
   TextButton,
   useGlobalConfig,
@@ -303,10 +304,29 @@ export function SettingsComponent({ exit }) {
         />
       </Accordion>
       <Accordion title="Email Types">
+        <h4>Delivery Emails</h4>
+        <Text>
+          Here you can configure emails to go out at various stages of a
+          delivery. Emails can be set up for both the delivery recipient and the
+          volunteer.
+        </Text>
         {Object.keys(globalConfig.get("email_types")).map((emailType) => {
           return <EmailTypeSettings key={emailType} emailType={emailType} />;
         })}
         <AddEmailTypeDialog />
+        <h4>Volunteer Emails</h4>
+        <Text>
+          Enable the setting below if you want to send volunteers a welcome
+          email when they first sign up.
+        </Text>
+        <Switch
+          value={globalConfig.get("enableVolunteerSignupEmail")}
+          onChange={(newValue) =>
+            globalConfig.setAsync("enableVolunteerSignupEmail", newValue)
+          }
+          label="Email volunteers on inital signup"
+          width="320px"
+        />
       </Accordion>
       <Accordion title="Template Variables">
         {["Deliveries", "Volunteers"].map((tableName) => {

--- a/send_email_messages/frontend/settings.js
+++ b/send_email_messages/frontend/settings.js
@@ -7,6 +7,7 @@ import {
   Heading,
   Input,
   InputSynced,
+  Label,
   SelectButtonsSynced,
   SelectSynced,
   Switch,
@@ -314,19 +315,41 @@ export function SettingsComponent({ exit }) {
           return <EmailTypeSettings key={emailType} emailType={emailType} />;
         })}
         <AddEmailTypeDialog />
-        <h4>Volunteer Emails</h4>
-        <Text>
-          Enable the setting below if you want to send volunteers a welcome
-          email when they first sign up.
-        </Text>
-        <Switch
-          value={globalConfig.get("enableVolunteerSignupEmail")}
-          onChange={(newValue) =>
-            globalConfig.setAsync("enableVolunteerSignupEmail", newValue)
-          }
-          label="Email volunteers on inital signup"
-          width="320px"
-        />
+        <Box>
+          <h4>Volunteer Emails</h4>
+          <Text>
+            Enable the setting below if you want to send volunteers a welcome
+            email when they first sign up.
+          </Text>
+          <Switch
+            value={!!globalConfig.get("enable_volunteer_welcome_email")}
+            onChange={(newValue) =>
+              globalConfig.setAsync("enable_volunteer_welcome_email", newValue)
+            }
+            label="Email volunteers on inital signup"
+            width="320px"
+          />
+          {globalConfig.get("enable_volunteer_welcome_email") ? (
+            <>
+              <Label htmlFor="volunteer-welcome-template-id-input">
+                Volunteer welcome email sendgrid template ID
+              </Label>
+              <Input
+                id="volunteer-welcome-template-id-input"
+                value={
+                  globalConfig.get("volunteer_welcome_email_template_id") || ""
+                }
+                onChange={(e) =>
+                  globalConfig.setAsync(
+                    "volunteer_welcome_email_template_id",
+                    e.target.value
+                  )
+                }
+                placeholder="Enter Sendgrid Template ID here"
+              />
+            </>
+          ) : null}
+        </Box>
       </Accordion>
       <Accordion title="Template Variables">
         {["Deliveries", "Volunteers"].map((tableName) => {


### PR DESCRIPTION
Work in progress PR.

Adds the ability to send initial confirmation emails to volunteers after they submit the form.

The main tricky design decision here is whether to try to fit this concept into the existing concept of "email types" based on delivery status. I opted to keep it separate (see the config screenshot below), honestly primarily because it makes the implementation a lot quicker, but also because I think it's a fine experience for the end user. It's a bit confusing when configuring, but that's something we've been doing internally so I'm not too concerned.

## Links
Main issue:  https://github.com/usdigitalresponse/neighbor-express/issues/159

## GIF/Screenshots:

<img width="820" alt="Screen_Shot_2020-07-14_at_10_42_13_PM" src="https://user-images.githubusercontent.com/934016/87551510-789dae00-c67e-11ea-8a70-1a52dffa9a74.png">
<img width="1535" alt="Screen_Shot_2020-07-14_at_10_44_16_PM" src="https://user-images.githubusercontent.com/934016/87551522-7cc9cb80-c67e-11ea-928a-56bd294568e6.png">



## How To Test:
* ...

## Feedback I'm looking for:

## Things left to do before deploying:
- [ ] ...
