### PR TITLE
Fix bug in the send emails logic

### DIFF
--- a/send_email_messages/frontend/send-messages.js
+++ b/send_email_messages/frontend/send-messages.js
@@ -18,14 +18,9 @@ async function sendMessage(messageToSend) {
   const EMAIL_TYPES = globalConfig.get("email_types");
 
   let templateId;
-  if (
-    messageToSend.getCellValue("Email type") ===
-    "Initial Confirmation: Volunteer"
-  ) {
-    templateId =
-      EMAIL_TYPES[messageToSend.getCellValue("Email type").name][
-        "sendgrid_template"
-      ];
+  const emailType = messageToSend.getCellValue("Email type").name;
+  if (emailType !== "Initial Confirmation: Volunteer") {
+    templateId = EMAIL_TYPES[emailType]["sendgrid_template"];
   } else {
     templateId = globalConfig.get("volunteer_welcome_email_template_id");
   }


### PR DESCRIPTION
When the email type to be sent **is** "Initial Confirmation: Volunteer", the volunteer_welcome template should be used. Else the template should be looked up from the global map.
The current code has it reversed, hence the wrong emails were getting sent.

TESTED=manually